### PR TITLE
LICENSE only for upstream work?

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,8 @@
+
+Missing license from https://github.com/jasonmeisel/v-hacd-unity ??
+
+------
+
 BSD 3-Clause License
 
 Copyright (c) 2011, Khaled Mamou (kmamou at gmail dot com)


### PR DESCRIPTION
Hey @jasonmeisel,

I was investigating if we could use this library but wasn't able to determine the license you've put it under. License only include Khaled Mamou I guess, since the license itself has been forked I don't want to make assumptions.

I see [Unity](https://github.com/Unity-Technologies/VHACD/blob/main/Third%20Party%20Notices.md) has your work down under an Apache 2.0 license but I'm unsure how they came to that conclusion. 😬 

So, would be great with some input from you. ✨ 🙏 